### PR TITLE
AV-583: removed general float left style from report body

### DIFF
--- a/ckanext/report/templates/report/view.html
+++ b/ckanext/report/templates/report/view.html
@@ -51,7 +51,7 @@
       {% if not are_some_results %}
         <p>{{ _('No results found.') }}</p>
       {% else %}
-        <div class="pull-left">
+        <div>
           {% snippet report_template, table=data['table'], data=data, report_name=report_name, options=options %}
         </div>
       {% endif %}


### PR DESCRIPTION
## Changes
Removed the styling from the report parent container. Allows better styling in children.

Everything seemed to work fine.
On mobile the new style didn't allow charts to overflow parent, so now they can be wrapped with flex-wrap.