### PR TITLE
fix(AV-1697): Fix csv-reports

### DIFF
--- a/ckanext/report/blueprint.py
+++ b/ckanext/report/blueprint.py
@@ -1,6 +1,6 @@
 from builtins import str
 import json
-from flask import Blueprint, request
+from flask import Blueprint, request, make_response
 
 import ckan.plugins.toolkit as t
 from . import helpers
@@ -115,13 +115,15 @@ def view(report_name, organization=None, refresh=False):
             except t.NotAuthorized:
                 t.abort(401)
             filename = 'report_%s.csv' % key
-            t.response.headers['Content-Type'] = 'application/csv'
-            t.response.headers['Content-Disposition'] = str('attachment; filename=%s' % (filename))
-            return make_csv_from_dicts(data['table'])
+            response = make_response(make_csv_from_dicts(data['table']), 200)
+            response.headers['Content-Type'] = 'application/csv'
+            response.headers['Content-Disposition'] = str('attachment; filename=%s' % (filename))
+            return response
         elif format == 'json':
-            t.response.headers['Content-Type'] = 'application/json'
             data['generated_at'] = report_date
-            return json.dumps(data)
+            response = make_response(json.dumps(data))
+            response.headers['Content-Type'] = 'application/json'
+            return response
         else:
             t.abort(400, 'Format not known - try html, json or csv')
 

--- a/ckanext/report/lib.py
+++ b/ckanext/report/lib.py
@@ -5,7 +5,7 @@ These functions are for use by other extensions for their reports.
 import ckan.plugins as p
 from past.builtins import basestring
 from collections import OrderedDict
-from datetime import datetime
+import datetime
 
 
 def all_organizations(include_none=False):
@@ -70,7 +70,7 @@ def percent(numerator, denominator):
 
 def make_csv_from_dicts(rows):
     import csv
-    import cStringIO as StringIO
+    import io as StringIO
 
     csvout = StringIO.StringIO()
     csvwriter = csv.writer(


### PR DESCRIPTION
- Use flasks make_response instead of toolkit.response to set headers as toolkit.response doesn't work anymore
- Fix datetime- and stringio-imports in lib.py