### PR TITLE
Parameterize fetching only orgs with packages

### DIFF
--- a/ckanext/report/helpers.py
+++ b/ckanext/report/helpers.py
@@ -49,10 +49,11 @@ def chunks(list_, size):
 
 
 def organization_list(only_orgs_with_packages=False):
-    organizations = tk.get_action('organization_list')({}, {'all_fields': True})
+    organizations = tk.get_action('organization_list')({}, {'all_fields': True, 'include_extras': True})
 
     result = ({'name': org.get('name'),
                'title': org.get('title'),
+               'title_translated': org.get('title_translated'),
                'package_count': org.get('package_count', 0)} for org in organizations if org.get('state') == 'active')
     if only_orgs_with_packages:
         result = (org for org in result if org.get('package_count', 0) > 0)

--- a/ckanext/report/templates/report/option_organization.html
+++ b/ckanext/report/templates/report/option_organization.html
@@ -17,8 +17,9 @@ default - Default value for this option
         {% if offer_organization_index %}
           <option value="" {% if value == None %}selected="selected"{% endif %}>-- {{ _('Index of all organizations') }} --</option>
         {% endif %}
-        {% for org_name, org_title in h.report__organization_list() %}
-            <option value="{{org_name}}" {% if value == org_name %}selected="selected" {% endif %}> {{org_title}} </option>
+        {% for org in h.report__organization_list(only_orgs_with_packages=True) %}
+            {% set title = h.get_translated(org, 'title') or org.get('title') or org.get('name') %}
+            <option value="{{org['name']}}" {% if value == org['name'] %}selected="selected" {% endif %}> {{ title }} </option>
         {% endfor %}
     </select>
 </span>


### PR DESCRIPTION
This is a bit on the fence between being general enough or making assumptions on the model (i.e. having localizations in the form of _translated) but it SHOULD work fine even without AND it is conforming to conventions so I'm hoping it's good enough. Comments are welcome!

* Add parameter to organization_list to only fetch organizations with packages
* Add support for localizations for the organization names